### PR TITLE
feat(android): allow disabling SSL verification

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -86,6 +86,10 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
         mRNCWebViewClient.setIgnoreErrFailedForThisURL(url);
     }
 
+    public void setAllowInsecureHttps(Boolean value) {
+        mRNCWebViewClient.setAllowInsecureHttps(value);
+    }
+
     public void setBasicAuthCredential(RNCBasicAuthCredential credential) {
         mRNCWebViewClient.setBasicAuthCredential(credential);
     }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -548,6 +548,11 @@ class RNCWebViewManagerImpl {
         view.settings.allowFileAccessFromFileURLs = value;
     }
 
+    fun setAllowInsecureHttps(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
+        view.setAllowInsecureHttps(value)
+    }
+
     fun setAllowsFullscreenVideo(viewWrapper: RNCWebViewWrapper, value: Boolean) {
         val view = viewWrapper.webView
         mAllowsFullscreenVideo = value

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -72,7 +72,11 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     @ReactProp(name = "allowFileAccessFromFileURLs")
     public void setAllowFileAccessFromFileURLs(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowFileAccessFromFileURLs(view, value);
+    }
 
+    @ReactProp(name = "allowInsecureHttps")
+    public void setAllowInsecureHttps(RNCWebViewWrapper view, boolean value) {
+        mRNCWebViewManagerImpl.setAllowInsecureHttps(view, value);
     }
 
     @Override

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -53,7 +53,11 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
     @ReactProp(name = "allowFileAccessFromFileURLs")
     public void setAllowFileAccessFromFileURLs(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowFileAccessFromFileURLs(view, value);
+    }
 
+    @ReactProp(name = "allowInsecureHttps")
+    public void setAllowInsecureHttps(RNCWebViewWrapper view, boolean value) {
+        mRNCWebViewManagerImpl.setAllowInsecureHttps(view, value);
     }
 
     @ReactProp(name = "allowUniversalAccessFromFileURLs")

--- a/docs/Reference.italian.md
+++ b/docs/Reference.italian.md
@@ -64,6 +64,7 @@ Questo documento elenca le attuali proprietà e metodi pubblici di React Native 
 - [`allowsBackForwardNavigationGestures`](Reference.italian.md#allowsbackforwardnavigationgestures)
 - [`incognito`](Reference.italian.md#incognito)
 - [`allowFileAccess`](Reference.italian.md#allowFileAccess)
+- [`allowInsecureHttps`](Reference.italian.md#allowInsecureHttps)
 - [`saveFormDataDisabled`](Reference.italian.md#saveFormDataDisabled)
 - [`cacheEnabled`](Reference.italian.md#cacheEnabled)
 - [`cacheMode`](Reference.italian.md#cacheMode)
@@ -1136,6 +1137,19 @@ Se impostato su `true`, consentirà l'accesso ai file di sistema tramite URI `fi
 | Tipo    | Obbligatorio | Piattaforma  |
 | ------- | ------------ | ------------ |
 | boolean | No           | Android      |
+
+---
+
+### `allowInsecureHttps`[⬆](#props-index)
+
+Boolean that sets whether SSL verification should be disabled for any URLs loaded in the WebView. The default value is `false`.
+
+> [!WARNING]
+> Setting this to `true` can expose your app to security vulnerabilities, and may result in your app being rejected from the Play Store.
+
+| Tipo | Obbligatorio | Piattaforma |
+|------|--------------|-------------|
+| bool | No           | Android     |
 
 ---
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -67,6 +67,7 @@ This document lays out the current public properties and methods for the React N
 - [`allowsBackForwardNavigationGestures`](Reference.md#allowsbackforwardnavigationgestures)
 - [`incognito`](Reference.md#incognito)
 - [`allowFileAccess`](Reference.md#allowFileAccess)
+- [`allowInsecureHttps`](Reference.md#allowInsecureHttps)
 - [`saveFormDataDisabled`](Reference.md#saveFormDataDisabled)
 - [`cacheEnabled`](Reference.md#cacheEnabled)
 - [`cacheMode`](Reference.md#cacheMode)
@@ -1229,6 +1230,19 @@ Boolean that sets whether JavaScript running in the context of a file scheme URL
 | Type | Required | Platform            |
 | ---- | -------- | ------------------- |
 | bool | No       | iOS, Android, macOS |
+
+---
+
+### `allowInsecureHttps`[⬆](#props-index)
+
+Boolean that sets whether SSL verification should be disabled for any URLs loaded in the WebView. The default value is `false`.
+
+> [!WARNING]
+> Setting this to `true` can expose your app to security vulnerabilities, and may result in your app being rejected from the Play Store.
+
+| Type | Required | Platform |
+| ---- | -------- |----------|
+| bool | No       | Android  |
 
 ---
 

--- a/docs/Reference.portuguese.md
+++ b/docs/Reference.portuguese.md
@@ -64,6 +64,7 @@ Este documento apresenta as propriedades e métodos públicos para o React Nativ
 - [`allowsBackForwardNavigationGestures`](Reference.portuguese.md#allowsbackforwardnavigationgestures)
 - [`incognito`](Reference.portuguese.md#incognito)
 - [`allowFileAccess`](Reference.portuguese.md#allowFileAccess)
+- [`allowInsecureHttps`](Reference.portuguese.md#allowInsecureHttps)
 - [`saveFormDataDisabled`](Reference.portuguese.md#saveFormDataDisabled)
 - [`cacheEnabled`](Reference.portuguese.md#cacheEnabled)
 - [`cacheMode`](Reference.portuguese.md#cacheMode)
@@ -1196,6 +1197,19 @@ Se true, isso permitirá o acesso ao sistema de arquivos por meio de URIs `file:
 | Tipo    | Requerido | Plataforma |
 | ------- | --------- | ---------- |
 | boolean | Não       | Android    |
+
+---
+
+### `allowInsecureHttps`[⬆](#props-index)
+
+Boolean that sets whether SSL verification should be disabled for any URLs loaded in the WebView. The default value is `false`.
+
+> [!WARNING]
+> Setting this to `true` can expose your app to security vulnerabilities, and may result in your app being rejected from the Play Store.
+
+| Tipo | Requerido | Plataforma |
+|------|-----------|------------|
+| bool | No        | Android    |
 
 ---
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -1010,6 +1010,12 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
   allowFileAccess?: boolean;
 
   /**
+   * A Boolean value indicating whether insecure HTTPS connections are allowed. The default value is `false`.
+   * @platform android
+   */
+  allowInsecureHttps?: boolean;
+
+  /**
    * Used on Android only, controls whether form autocomplete data should be saved
    * @platform android
    */


### PR DESCRIPTION
Enables switching SSL verification on/off using an `allowsInsecureHttps` prop.

Inspired by [this comment](https://github.com/react-native-webview/react-native-webview/issues/1834#issuecomment-1583796593) left on #1834.

Fixes #1834